### PR TITLE
Not Breaking - Adds support for ENV, cluster connection, password auth, tls handshakes, bull metrics, auto-removal of failed jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Allows for the creation of one to many queues to offload the execution of Wappler library tasks
 
 ## Requirements
-* Functioning Redis connection, specified within the Wappler server config
+* Functioning Redis connection, specified within the Wappler server config or a Redis connection defined with ENV variables
 
 ## Installation
 * In your project folder, create /extensions/server_connect/modules (if it does not yet exist)
@@ -37,6 +37,7 @@ All actions require a queue name be provided
 * Optionally create a queue with the default set of parameters (see below)
 * Optionally delay job x number of milliseconds
 * Optionally remove the job from the queue when completed
+* Optionally remove the job from the queue when failed
 * Responds with the job id
 
 ### Queue Status

--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ Allows for the creation of one to many queues to offload the execution of Wapple
 * The required libraries will be installed automatically upon use and next deployment
 * You should now have a Bull Queues group in your available actions list for server workflows
 
+## Optional ENV Variables
+* REDIS_PORT: The Redis port
+* REDIS_HOST: The Redis host
+* REDIS_BULL_QUEUE_DB: The Redis database for bull queues
+* REDIS_PASSWORD: The Redis password
+* REDIS_USER: The Redis user
+* REDIS_TLS: The TLS certificate. Define it is {} if you need a TLS connection without defining a cert.
+* REDIS_PREFIX: The prefix for the database. This is useful if you need to connect to a clusert.
+* REDIS_BULL_METRICS: Boolean. Enables Bull metrics collection which can be visualised with a GUI like https://taskforce.sh/
+* REDIS_BULL_METRICS_TIME: The timeframe for metric collection. Defaults to TWO_WEEKS if metrics are enabled
+
 ## Actions
 All actions require a queue name be provided
 

--- a/bull_processor_api.js
+++ b/bull_processor_api.js
@@ -1,25 +1,23 @@
-// JavaScript Document
-const axios = require('axios');
-//const App = require('../../../lib/core/app');
+const axios = require("axios");
 
-
-module.exports = async (job, done) => {
+module.exports = async(job, done) => {
     try {
         job = {
-            ...job, ...job.data.jobData
-        }
+            ...job,
+            ...job.data.jobData,
+        };
 
         let apiURL = job.data.baseURL + job.data.action;
 
-        axios.post(apiURL, job, { timeout: 120000 })
+        axios
+            .post(apiURL, job, { timeout: 120000 })
             .then(() => {
                 done();
-            }).catch((err) => {
-                done(err)
+            })
+            .catch((err) => {
+                done(err);
             });
-
     } catch (error) {
-
+        done(error);
     }
-
-}
+};

--- a/bull_queues.hjson
+++ b/bull_queues.hjson
@@ -542,6 +542,16 @@
             defaultValue: false,
             serverDataBindings: true,
             help: 'If ticked, removes the job from the queue if successfully completed.'
+        },
+        { 
+            name: 'remove_on_fail', 
+            optionName: 'remove_on_fail', 
+            title: 'Remove on fail', 
+            type: 'boolean', 
+            required: false, 
+            defaultValue: false,
+            serverDataBindings: true,
+            help: 'If ticked, removes the job from the queue if the job failed.'
         }
         ]
       }

--- a/bull_queues.js
+++ b/bull_queues.js
@@ -17,7 +17,12 @@ const defaultQueueOptions = {
         ...(process.env.REDIS_USER || global.redisClient.options.user ? { username: process.env.REDIS_USER || global.redisClient.options.user } : {}),
         ...(process.env.REDIS_TLS || global.redisClient.options.tls ? { tls: {} } : {}),
         ...(process.env.REDIS_PREFIX ? { prefix: `{${process.env.REDIS_PREFIX}}` } : {}),
-        ...(process.env.REDIS_BULL_METRICS ? { metrics: { maxDataPoints: process.env.REDIS_BULL_METRICS_TIME || Queue.utils.MetricsTime.TWO_WEEKS } } : {})
+        ...(process.env.REDIS_BULL_METRICS ? {
+            metrics: {
+                maxDataPoints: process.env.REDIS_BULL_METRICS_TIME ?
+                    Queue.utils.MetricsTime[process.env.REDIS_BULL_METRICS_TIME] : Queue.utils.MetricsTime.TWO_WEEKS,
+            },
+        } : {}),
     }
 };
 

--- a/bull_queues.js
+++ b/bull_queues.js
@@ -21,8 +21,6 @@ const defaultQueueOptions = {
     }
 };
 
-
-
 var bullQueues = [];
 var workerCounts = [];
 var processorTypes = [];
@@ -412,6 +410,7 @@ exports.add_job_api = async function(options) {
 
         let queueName = this.parseRequired(options.queue_name, 'string', 'Queue name is required');
         let remove_on_complete = this.parseOptional(options.remove_on_complete, 'boolean', false);
+        let remove_on_fail = this.parseOptional(options.remove_on_fail, 'boolean', false);
         let attempts = parseInt(this.parseOptional(options.attempts, '*', 1));
 
         setupQueue(queueName);
@@ -445,6 +444,7 @@ exports.add_job_api = async function(options) {
                 }, {
                     delay: delay_ms,
                     removeOnComplete: remove_on_complete,
+                    removeOnFail: remove_on_fail,
                     attempts: attempts
                 }).catch(console.error);
 


### PR DESCRIPTION
Add support for:

- ENV variables in Redis connection parameters
- DB cluster
- Bull Metrics
- Password authentication,
- TLS
- Removal of failed jobs
- Error handling of queue processor
- Updated Readme

The connection doesn't break previous versions. It adds support to define the DB parameters via ENV variables but falls back to globals if these are not defined. It handles global TLS, password, and user from the global redis client inside Wappler as well.
